### PR TITLE
init capacity

### DIFF
--- a/Assets/RTLTMPro/Scripts/Runtime/FastStringBuilder.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/FastStringBuilder.cs
@@ -161,7 +161,7 @@ namespace RTLTMPro {
         }
 
         public override string ToString() {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(length * 2);
             for (int i = 0; i < length; i++) {
                 sb.Append(char.ConvertFromUtf32(array[i]));
             }
@@ -170,10 +170,10 @@ namespace RTLTMPro {
 
         public string ToDebugString()
         {
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder(length * 3);
             for (int i = 0; i < length; i++)
             {
-                sb.Append("\\");
+                sb.Append('\\');
                 sb.Append(array[i].ToString("X"));
             }
             return sb.ToString();


### PR DESCRIPTION
1. `ToString`  avoid StringBuilder resize due to capacity
2.  `ToDebugString `  chang append (string) -> append(char)