### PR TITLE
Fix rtl textrich taging

### DIFF
--- a/Assets/RTLTMPro/Scripts/Runtime/FastStringBuilder.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/FastStringBuilder.cs
@@ -2,20 +2,25 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Text;
-namespace RTLTMPro {
-    public class FastStringBuilder {
+namespace RTLTMPro
+{
+    public class FastStringBuilder
+    {
         // Using fields to be as efficient as possible
         private int length;
-        public int Length {
+        public int Length
+        {
             get { return length; }
-            set {
+            set
+            {
                 if (value <= length) length = value;
             }
         }
         private int[] array;
         private int capacity;
 
-        public FastStringBuilder(int capacity) {
+        public FastStringBuilder(int capacity)
+        {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
@@ -23,39 +28,48 @@ namespace RTLTMPro {
             array = new int[capacity];
         }
 
-        public FastStringBuilder(string text) : this(text, text.Length) {
+        public FastStringBuilder(string text) : this(text, text.Length)
+        {
         }
 
-        public FastStringBuilder(string text, int capacity) : this(capacity) {
+        public FastStringBuilder(string text, int capacity) : this(capacity)
+        {
             SetValue(text);
         }
 
-        public static implicit operator string(FastStringBuilder x) {
+        public static implicit operator string(FastStringBuilder x)
+        {
             return x.ToString();
         }
 
-        public static implicit operator FastStringBuilder(string x) {
+        public static implicit operator FastStringBuilder(string x)
+        {
             return new FastStringBuilder(x);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int Get(int index) {
+        public int Get(int index)
+        {
             return array[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Set(int index, int ch) {
+        public void Set(int index, int ch)
+        {
             array[index] = ch;
         }
 
-        public void SetValue(string text) {
+        public void SetValue(string text)
+        {
             int len = 0;
             length = text.Length;
             EnsureCapacity(length, false);
 
-            for (int i = 0; i < text.Length; i++) {
+            for (int i = 0; i < text.Length; i++)
+            {
                 int unicode32CodePoint = char.ConvertToUtf32(text, i);
-                if (unicode32CodePoint > 0xffff) {
+                if (unicode32CodePoint > 0xffff)
+                {
                     i++;
                 }
                 array[len++] = unicode32CodePoint;
@@ -64,13 +78,15 @@ namespace RTLTMPro {
             length = len;
         }
 
-        public void SetValue(FastStringBuilder other) {
+        public void SetValue(FastStringBuilder other)
+        {
             EnsureCapacity(other.length, false);
             Copy(other.array, array);
             length = other.length;
         }
 
-        public void Append(int ch) {
+        public void Append(int ch)
+        {
             length++;
             if (capacity < length)
                 EnsureCapacity(length, true);
@@ -78,7 +94,8 @@ namespace RTLTMPro {
             array[length - 1] = ch;
         }
 
-        public void Append(char ch) {
+        public void Append(char ch)
+        {
             length++;
             if (capacity < length)
                 EnsureCapacity(length, true);
@@ -86,27 +103,32 @@ namespace RTLTMPro {
             array[length - 1] = ch;
         }
 
-        public void Insert(int pos, FastStringBuilder str, int offset, int count) {
+        public void Insert(int pos, FastStringBuilder str, int offset, int count)
+        {
             if (str == this) throw new InvalidOperationException("You cannot pass the same string builder to insert");
             if (count == 0) return;
 
             length += count;
             EnsureCapacity(length, true);
 
-            for (int i = length - count - 1; i >= pos; i--) {
+            for (int i = length - count - 1; i >= pos; i--)
+            {
                 array[i + count] = array[i];
             }
 
-            for (int i = 0; i < count; i++) {
+            for (int i = 0; i < count; i++)
+            {
                 array[pos + i] = str.array[offset + i];
             }
         }
 
-        public void Insert(int pos, FastStringBuilder str) {
+        public void Insert(int pos, FastStringBuilder str)
+        {
             Insert(pos, str, 0, str.length);
         }
 
-        public void Insert(int pos, int ch) {
+        public void Insert(int pos, int ch)
+        {
             length++;
             EnsureCapacity(length, true);
 
@@ -116,10 +138,12 @@ namespace RTLTMPro {
             array[pos] = ch;
         }
 
-        public void RemoveAll(int character) {
+        public void RemoveAll(int character)
+        {
             int j = 0; // write index
             int i = 0; // read index
-            for (; i < length; i++) {
+            for (; i < length; i++)
+            {
                 if (array[i] == character) continue;
 
                 array[j] = array[i];
@@ -129,16 +153,20 @@ namespace RTLTMPro {
             length = j;
         }
 
-        public void Remove(int start, int length) {
-            for (int i = start; i < this.length - length; i++) {
+        public void Remove(int start, int length)
+        {
+            for (int i = start; i < this.length - length; i++)
+            {
                 array[i] = array[i + length];
             }
 
             this.length -= length;
         }
 
-        public void Reverse(int startIndex, int length) {
-            for (int i = 0; i < length / 2; i++) {
+        public void Reverse(int startIndex, int length)
+        {
+            for (int i = 0; i < length / 2; i++)
+            {
                 int firstIndex = startIndex + i;
                 int secondIndex = startIndex + length - i - 1;
 
@@ -150,31 +178,61 @@ namespace RTLTMPro {
             }
         }
 
-        public void Reverse() {
+        public void Reverse()
+        {
             Reverse(0, length);
         }
 
-        public void Substring(FastStringBuilder output, int start, int length) {
+        public void Substring(FastStringBuilder output, int start, int length)
+        {
             output.length = 0;
             for (int i = 0; i < length; i++)
                 output.Append(array[start + i]);
         }
-
-        public override string ToString() {
+        public string get_str(int index)
+        {
+            return char.ConvertFromUtf32(array[index]);
+        }
+        public override string ToString()
+        {
             StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < length; i++) {
+            for (int i = 0; i < length; i++)
+            {
                 sb.Append(char.ConvertFromUtf32(array[i]));
             }
             return sb.ToString();
         }
 
-        public void Replace(int oldChar, int newChar) {
-            for (int i = 0; i < length; i++) {
+        public void Replace(int oldChar, int newChar)
+        {
+            for (int i = 0; i < length; i++)
+            {
                 if (array[i] == oldChar)
                     array[i] = newChar;
             }
         }
-
+        public void ReplaceOne(int oldChar, int newChar)
+        {
+            for (int i = 0; i < length; i++)
+            {
+                if (array[i] == oldChar)
+                {
+                    array[i] = newChar;
+                    break;
+                }
+            }
+        }
+        public void ReplaceOne(int oldChar, int newChar, int start)
+        {
+            for (int i = start; i < length; i++)
+            {
+                if (array[i] == oldChar)
+                {
+                    array[i] = newChar;
+                    break;
+                }
+            }
+        }
         public void Replace(FastStringBuilder oldStr, FastStringBuilder newStr)
         {
             for (int i = 0; i < length; i++)
@@ -240,11 +298,13 @@ namespace RTLTMPro {
             }
         }
 
-        public void Clear() {
+        public void Clear()
+        {
             length = 0;
         }
 
-        private void EnsureCapacity(int cap, bool keepValues) {
+        private void EnsureCapacity(int cap, bool keepValues)
+        {
             if (capacity >= cap)
                 return;
 
@@ -254,16 +314,20 @@ namespace RTLTMPro {
             while (capacity < cap)
                 capacity *= 2;
 
-            if (keepValues) {
+            if (keepValues)
+            {
                 int[] newArray = new int[capacity];
                 Copy(array, newArray);
                 array = newArray;
-            } else {
+            }
+            else
+            {
                 array = new int[capacity];
             }
         }
 
-        private static void Copy(int[] src, int[] dst) {
+        private static void Copy(int[] src, int[] dst)
+        {
             for (int i = 0; i < src.Length; i++)
                 dst[i] = src[i];
         }

--- a/Assets/RTLTMPro/Scripts/Runtime/GlyphFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/GlyphFixer.cs
@@ -32,7 +32,71 @@ namespace RTLTMPro
             [(char)EnglishNumbers.Nine] = (char)HinduNumbers.Nine,
         };
 
+        public static void Fix_Taged(FastStringBuilder output, FastStringBuilder originalshape, bool farsi)
+        {
 
+            FixLa(output);
+            FixLa(originalshape);
+            int j = 0; // write index
+            for (int i = 0; i < output.Length; i++)
+            {
+                int iChar = output.Get(i);
+
+                if (iChar < 0xFFFF && TextUtils.IsGlyphFixedArabicCharacter((char)iChar))
+                {
+                    int jChar = originalshape.Get(j);
+
+                    if (jChar < 0xFFFF && TextUtils.IsGlyphFixedArabicCharacter((char)jChar))
+                    {
+                        output.ReplaceOne(iChar, jChar, i);
+                        j++;
+                    }
+                }
+            }
+
+        }
+        public static void FixYah(FastStringBuilder str)
+        {
+            int j = 0;
+            for (int i = 0; i < str.Length; i++)
+            {
+                int iChar = str.Get(i);
+                if (iChar < 0xFFFF && TextUtils.IsGlyphFixedArabicCharacter((char)iChar))
+                {
+
+
+                    int iChar_next = str.Get(j);
+
+                    string jStr = iChar.ToString("X");
+                    string jStr_next = iChar_next.ToString("X");
+                    //  && jStr_next == "FBFC"
+                    if (i == 0 && jStr == "FBFC")
+                    {
+                        str.ReplaceOne(iChar, 0xFBFD);
+                    }
+
+                    j++;
+                }
+            }
+        }
+        public static void FixLa(FastStringBuilder str)
+        {
+            for (int i = 0; i < str.Length; i++)
+            {
+                int iChar = str.Get(i);
+                if (iChar < 0xFFFF && TextUtils.IsGlyphFixedArabicCharacter((char)iChar))
+                {
+
+                    string jStr = iChar.ToString("X");
+                    if (jStr == "FEFC" || jStr == "FEFB")
+                    {
+                        str.ReplaceOne(iChar, 0xFE8E, i);
+                        str.Insert(i + 1, 0xFEE0);
+                    }
+
+                }
+            }
+        }
         /// <summary>
         ///     Fixes the shape of letters based on their position.
         /// </summary>
@@ -77,10 +141,12 @@ namespace RTLTMPro
                     if (IsMiddleLetter(input, i))
                     {
                         output.Set(i, (char)(converted + 3));
-                    } else if (IsFinishingLetter(input, i))
+                    }
+                    else if (IsFinishingLetter(input, i))
                     {
                         output.Set(i, (char)(converted + 1));
-                    } else if (IsLeadingLetter(input, i))
+                    }
+                    else if (IsLeadingLetter(input, i))
                     {
                         output.Set(i, (char)(converted + 2));
                     }
@@ -99,7 +165,8 @@ namespace RTLTMPro
                 if (fixTextTags)
                 {
                     FixNumbersOutsideOfTags(output, farsi);
-                } else
+                }
+                else
                 {
                     FixNumbers(output, farsi);
                 }
@@ -119,7 +186,8 @@ namespace RTLTMPro
                 if (farsi && text.Get(i) == (int)ArabicGeneralLetters.Ya)
                 {
                     text.Set(i, (char)ArabicGeneralLetters.PersianYa);
-                } else if (farsi == false && text.Get(i) == (int)ArabicGeneralLetters.PersianYa)
+                }
+                else if (farsi == false && text.Get(i) == (int)ArabicGeneralLetters.PersianYa)
                 {
                     text.Set(i, (char)ArabicGeneralLetters.Ya);
                 }
@@ -209,7 +277,8 @@ namespace RTLTMPro
                         if ((j == i + 1 && jChar == ' ') || jChar == '<')
                         {
                             break;
-                        } else if (jChar == '>')
+                        }
+                        else if (jChar == '>')
                         {
                             i = j;
                             sawValidTag = true;

--- a/Assets/RTLTMPro/Scripts/Runtime/GlyphFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/GlyphFixer.cs
@@ -55,30 +55,6 @@ namespace RTLTMPro
             }
 
         }
-        public static void FixYah(FastStringBuilder str)
-        {
-            int j = 0;
-            for (int i = 0; i < str.Length; i++)
-            {
-                int iChar = str.Get(i);
-                if (iChar < 0xFFFF && TextUtils.IsGlyphFixedArabicCharacter((char)iChar))
-                {
-
-
-                    int iChar_next = str.Get(j);
-
-                    string jStr = iChar.ToString("X");
-                    string jStr_next = iChar_next.ToString("X");
-                    //  && jStr_next == "FBFC"
-                    if (i == 0 && jStr == "FBFC")
-                    {
-                        str.ReplaceOne(iChar, 0xFBFD);
-                    }
-
-                    j++;
-                }
-            }
-        }
         public static void FixLa(FastStringBuilder str)
         {
             for (int i = 0; i < str.Length; i++)

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLSupport.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLSupport.cs
@@ -15,7 +15,43 @@ namespace RTLTMPro
             inputBuilder = new FastStringBuilder(DefaultBufferSize);
             glyphFixerOutput = new FastStringBuilder(DefaultBufferSize);
         }
+        /// <summary>
+        ///     Fixes the provided string
+        /// </summary>
+        /// <param name="input">Text to fix</param>
+        /// <param name="output">Fixed text</param>
+        /// <param name="originalShapes">Original text shapes</param>
+        /// <param name="fixTextTags"></param>
+        /// <param name="preserveNumbers"></param>
+        /// <param name="farsi"></param>
+        /// <returns>Fixed text</returns>
+        public static void FixRTL(
+            string input,
+            FastStringBuilder output,
+            FastStringBuilder originalShapes,
+            bool farsi = true,
+            bool fixTextTags = true,
+            bool preserveNumbers = false)
+        {
+            inputBuilder.SetValue(input);
+            TashkeelFixer.RemoveTashkeel(inputBuilder);
+            // The shape of the letters in shapeFixedLetters is fixed according to their position in word. But the flow of the text is not fixed.
+            GlyphFixer.Fix(inputBuilder, glyphFixerOutput, preserveNumbers, farsi, fixTextTags);
 
+            //Restore tashkeel to their places.
+            TashkeelFixer.RestoreTashkeel(glyphFixerOutput);
+
+            TashkeelFixer.FixShaddaCombinations(glyphFixerOutput);
+            // Fix flow of the text and put the result in FinalLetters field
+            LigatureFixer.Fix(glyphFixerOutput, output, farsi, fixTextTags, preserveNumbers);
+            if (fixTextTags)
+            {
+                RichTextFixer.Fix(output);
+                GlyphFixer.Fix_Taged(output, originalShapes, farsi);
+                // GlyphFixer.Fix(glyphFixerOutput, output, preserveNumbers, farsi, fixTextTags);
+            }
+            inputBuilder.Clear();
+        }
         /// <summary>
         ///     Fixes the provided string
         /// </summary>
@@ -38,7 +74,7 @@ namespace RTLTMPro
             GlyphFixer.Fix(inputBuilder, glyphFixerOutput, preserveNumbers, farsi, fixTextTags);
             //Restore tashkeel to their places.
             TashkeelFixer.RestoreTashkeel(glyphFixerOutput);
-            
+
             TashkeelFixer.FixShaddaCombinations(glyphFixerOutput);
             // Fix flow of the text and put the result in FinalLetters field
             LigatureFixer.Fix(glyphFixerOutput, output, farsi, fixTextTags, preserveNumbers);

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
@@ -86,13 +86,15 @@ namespace RTLTMPro
 
         [SerializeField] protected bool farsi = true;
 
-        [SerializeField] [TextArea(3, 10)] protected string originalText;
+        [SerializeField][TextArea(3, 10)] protected string originalText;
 
         [SerializeField] protected bool fixTags = true;
 
         [SerializeField] protected bool forceFix;
 
         protected readonly FastStringBuilder finalText = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+        protected FastStringBuilder original_untaged = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+        protected FastStringBuilder original_untaged_fixed = new FastStringBuilder(RTLSupport.DefaultBufferSize);
 
         protected void Update()
         {
@@ -111,22 +113,43 @@ namespace RTLTMPro
             {
                 isRightToLeftText = false;
                 base.text = originalText;
-            } else
+            }
+            else
             {
+                // Get The Untaged version of the text
+                original_untaged.Clear();
+                RichTextFixer.GetUntaged(originalText, original_untaged);
+                original_untaged_fixed.Clear();
+                RTLSupport.FixRTL(original_untaged.ToString(), original_untaged_fixed, farsi, fixTags, preserveNumbers);
+                // original_untaged_fixed.Reverse();
+
                 isRightToLeftText = true;
                 base.text = GetFixedText(originalText);
             }
 
             havePropertiesChanged = true;
         }
+        public void add_tag(string tag, string seprator, int index)
+        {
+            FastStringBuilder text = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+            text.SetValue(originalText);
 
+            string taged_value = tag.Replace(seprator, text.get_str(index));
+            text.Remove(index, 1);
+            text.Insert(index, taged_value);
+
+            originalText = text.ToString();
+            UpdateText();
+        }
         private string GetFixedText(string input)
         {
             if (string.IsNullOrEmpty(input))
                 return input;
 
             finalText.Clear();
-            RTLSupport.FixRTL(input, finalText, farsi, fixTags, preserveNumbers);
+            // RTLSupport.FixRTL(input, finalText, farsi, fixTags, preserveNumbers);
+            // RTLFix with the untaged version for converting the taged text.
+            RTLSupport.FixRTL(input, finalText, original_untaged_fixed, farsi, fixTags, preserveNumbers);
             finalText.Reverse();
             return finalText.ToString();
         }

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
@@ -86,13 +86,16 @@ namespace RTLTMPro
 
         [SerializeField] protected bool farsi = true;
 
-        [SerializeField] [TextArea(3, 10)] protected string originalText;
+        [SerializeField][TextArea(3, 10)] protected string originalText;
 
         [SerializeField] protected bool fixTags = true;
 
         [SerializeField] protected bool forceFix;
 
         protected readonly FastStringBuilder finalText = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+        protected FastStringBuilder original_untaged = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+        protected FastStringBuilder original_untaged_fixed = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+
 
         protected void Update()
         {
@@ -114,20 +117,40 @@ namespace RTLTMPro
             }
             else
             {
+                // Get The Untaged version of the text
+                original_untaged.Clear();
+                RichTextFixer.GetUntaged(originalText, original_untaged);
+                original_untaged_fixed.Clear();
+                RTLSupport.FixRTL(original_untaged.ToString(), original_untaged_fixed, farsi, fixTags, preserveNumbers);
+                // original_untaged_fixed.Reverse();
+
                 isRightToLeftText = true;
                 base.text = GetFixedText(originalText);
             }
 
             havePropertiesChanged = true;
         }
+        public void add_tag(string tag, string seprator, int index)
+        {
+            FastStringBuilder text = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+            text.SetValue(originalText);
 
+            string taged_value = tag.Replace(seprator, text.get_str(index));
+            text.Remove(index, 1);
+            text.Insert(index, taged_value);
+
+            originalText = text.ToString();
+            UpdateText();
+        }
         private string GetFixedText(string input)
         {
             if (string.IsNullOrEmpty(input))
                 return input;
 
             finalText.Clear();
-            RTLSupport.FixRTL(input, finalText, farsi, fixTags, preserveNumbers);
+            // RTLSupport.FixRTL(input, finalText, farsi, fixTags, preserveNumbers);
+            // RTLFix with the untaged version for converting the taged text.
+            RTLSupport.FixRTL(input, finalText, original_untaged_fixed, farsi, fixTags, preserveNumbers);
             finalText.Reverse();
 
             return finalText.ToString();

--- a/Assets/RTLTMPro/Scripts/Runtime/RichTextFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RichTextFixer.cs
@@ -26,30 +26,6 @@ namespace RTLTMPro
             }
         }
         /// <summary>
-        ///     Fixes rich text tags in input string with the original shape of the RTL text and returns the result.
-        /// </summary>
-        public static void Fix(FastStringBuilder text, FastStringBuilder originalShapes)
-        {
-            for (int i = 0; i < text.Length; i++)
-            {
-                FindTag(text, i, out Tag tag);
-
-                // If we couldn't find a tag, end the process
-                if (tag.Type == TagType.None)
-                {
-                    break;
-                }
-
-                text.Reverse(tag.Start, tag.End - tag.Start + 1);
-                i = tag.End;
-            }
-            for (int i = 0; i < originalShapes.Length; i++)
-            {
-                text.Replace(originalShapes.Get(i), originalShapes.Get(i));
-            }
-
-        }
-        /// <summary>
         ///     Fixes rich text tags in input string and returns the result.
         /// </summary>
         public static void Fix(FastStringBuilder text)

--- a/Assets/RTLTMPro/Scripts/Runtime/RichTextFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RichTextFixer.cs
@@ -25,7 +25,30 @@ namespace RTLTMPro
                 HashCode = hashCode;
             }
         }
+        /// <summary>
+        ///     Fixes rich text tags in input string with the original shape of the RTL text and returns the result.
+        /// </summary>
+        public static void Fix(FastStringBuilder text, FastStringBuilder originalShapes)
+        {
+            for (int i = 0; i < text.Length; i++)
+            {
+                FindTag(text, i, out Tag tag);
 
+                // If we couldn't find a tag, end the process
+                if (tag.Type == TagType.None)
+                {
+                    break;
+                }
+
+                text.Reverse(tag.Start, tag.End - tag.Start + 1);
+                i = tag.End;
+            }
+            for (int i = 0; i < originalShapes.Length; i++)
+            {
+                text.Replace(originalShapes.Get(i), originalShapes.Get(i));
+            }
+
+        }
         /// <summary>
         ///     Fixes rich text tags in input string and returns the result.
         /// </summary>
@@ -46,7 +69,27 @@ namespace RTLTMPro
                 i = tag.End;
             }
         }
+        /// <summary>
+        ///     Fixes rich text untaged in input string and returns the result.
+        /// </summary>
+        public static void GetUntaged(string text, FastStringBuilder output)
+        {
+            FastStringBuilder taged_string = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+            taged_string.SetValue(text);
 
+            for (int i = 0; i < taged_string.Length; i++)
+            {
+                FindTag(taged_string, i, out Tag tag);
+
+                // If we couldn't find a tag, end the process
+                if (tag.Type == TagType.None) break;
+                i = 0;
+
+                taged_string.Remove(tag.Start, tag.End - tag.Start + 1);
+
+            }
+            output.Append(taged_string);
+        }
         public static void FindTag(
             FastStringBuilder str,
             int start,

--- a/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
@@ -6,29 +6,29 @@ namespace RTLTMPro
     public static class TextUtils
     {
         // Every English character is between these two
-        private const char LowerCaseA = (char) 0x61;
-        private const char UpperCaseA = (char) 0x41;
-        private const char LowerCaseZ = (char) 0x7A;
-        private const char UpperCaseZ = (char) 0x5A;
+        private const char LowerCaseA = (char)0x61;
+        private const char UpperCaseA = (char)0x41;
+        private const char LowerCaseZ = (char)0x7A;
+        private const char UpperCaseZ = (char)0x5A;
 
-        private const char HebrewLow  = (char) 0x591;
-        private const char HebrewHigh = (char) 0x5F4;
+        private const char HebrewLow = (char)0x591;
+        private const char HebrewHigh = (char)0x5F4;
 
         // base, extended and supplement blocks are the isolated forms which will convert to presentation forms by the textbox.
-        private const char ArabicBaseBlockLow  = (char) 0x600;
-        private const char ArabicBaseBlockHigh = (char) 0x6FF;
+        private const char ArabicBaseBlockLow = (char)0x600;
+        private const char ArabicBaseBlockHigh = (char)0x6FF;
 
-        private const char ArabicExtendedABlockLow  = (char)0x8A0;
+        private const char ArabicExtendedABlockLow = (char)0x8A0;
         private const char ArabicExtendedABlockHigh = (char)0x8FF;
 
-        private const char ArabicExtendedBBlockLow  = (char)0x870;
+        private const char ArabicExtendedBBlockLow = (char)0x870;
         private const char ArabicExtendedBBlockHigh = (char)0x89F;
 
         // presentation forms are final and will be preserved by the textbox
-        private const char ArabicPresentationFormsABlockLow  = (char)0xFB50;
+        private const char ArabicPresentationFormsABlockLow = (char)0xFB50;
         private const char ArabicPresentationFormsABlockHigh = (char)0xFDFF;
 
-        private const char ArabicPresentationFormsBBlockLow  = (char)0xFE70;
+        private const char ArabicPresentationFormsBBlockLow = (char)0xFE70;
         private const char ArabicPresentationFormsBBlockHigh = (char)0xFEFF;
 
         public static bool IsPunctuation(char ch)
@@ -49,17 +49,17 @@ namespace RTLTMPro
 
         public static bool IsEnglishNumber(char ch)
         {
-            return ch >= (char) EnglishNumbers.Zero && ch <= (char) EnglishNumbers.Nine;
+            return ch >= (char)EnglishNumbers.Zero && ch <= (char)EnglishNumbers.Nine;
         }
 
         public static bool IsFarsiNumber(char ch)
         {
-            return ch >= (char) FarsiNumbers.Zero && ch <= (char) FarsiNumbers.Nine;
+            return ch >= (char)FarsiNumbers.Zero && ch <= (char)FarsiNumbers.Nine;
         }
 
         public static bool IsHinduNumber(char ch)
         {
-            return ch >= (char) HinduNumbers.Zero && ch <= (char) HinduNumbers.Nine;
+            return ch >= (char)HinduNumbers.Zero && ch <= (char)HinduNumbers.Nine;
         }
 
         public static bool IsEnglishLetter(char ch)
@@ -67,11 +67,13 @@ namespace RTLTMPro
             return ch >= UpperCaseA && ch <= UpperCaseZ || ch >= LowerCaseA && ch <= LowerCaseZ;
         }
 
-        public static bool IsHebrewCharacter(char ch) {
+        public static bool IsHebrewCharacter(char ch)
+        {
             return ch >= HebrewLow && ch <= HebrewHigh;
         }
 
-        public static bool IsArabicCharacter(char ch) {
+        public static bool IsArabicCharacter(char ch)
+        {
             return ch >= ArabicBaseBlockLow && ch <= ArabicBaseBlockHigh
                 || ch >= ArabicExtendedABlockLow && ch <= ArabicExtendedABlockHigh
                 || ch >= ArabicExtendedBBlockLow && ch <= ArabicExtendedBBlockHigh
@@ -84,7 +86,8 @@ namespace RTLTMPro
         /// </summary>
         /// <param name="ch">Character to check</param>
         /// <returns><see langword="true" /> if character is supported. otherwise <see langword="false" /></returns>
-        public static bool IsRTLCharacter(char ch) {
+        public static bool IsRTLCharacter(char ch)
+        {
             if (IsHebrewCharacter(ch)) return true;
             if (IsArabicCharacter(ch)) return true;
             return false;
@@ -329,6 +332,18 @@ namespace RTLTMPro
                 return true;
             }
 
+            // Special La with sin and alef
+            if (ch == 0xFEFC)
+            {
+                return true;
+            }
+
+            // Special La with alef
+            if (ch == 0xFEFB)
+            {
+                return true;
+            }
+
             if (ch == 0xFEF5)
             {
                 return true;
@@ -395,7 +410,7 @@ namespace RTLTMPro
 
             return false;
         }
-        
+
         /// <summary>
         ///     Checks if the input string starts with supported RTL character or not.
         /// </summary>

--- a/Assets/RTLTMPro/Tests/RichTextFixerTests.cs
+++ b/Assets/RTLTMPro/Tests/RichTextFixerTests.cs
@@ -10,57 +10,57 @@ namespace RTLTMPro.Tests
         {
             // Arrange
             var text = new FastStringBuilder("text <opening> text");
-            
+
             // Act
             RichTextFixer.FindTag(text, 0, out var tag);
-            
+
             // Assert
             Assert.AreEqual(RichTextFixer.TagType.Opening, tag.Type);
             Assert.AreEqual(5, tag.Start);
             Assert.AreEqual(13, tag.End);
         }
-        
+
         [Test]
         public void FindTag_FindsOpeningTagWithSpaceInside()
         {
             // Arrange
             var text = new FastStringBuilder("text <ope ning> text");
-            
+
             // Act
             RichTextFixer.FindTag(text, 0, out var tag);
-            
+
             // Assert
             Assert.AreEqual(RichTextFixer.TagType.Opening, tag.Type);
             Assert.AreEqual(5, tag.Start);
             Assert.AreEqual(14, tag.End);
         }
-        
+
         [Test]
         public void FindTag_FindsOpeningTagWithValue()
         {
             // Arrange
             var text = new FastStringBuilder("text <opening=12m> text");
-            
+
             // Act
             RichTextFixer.FindTag(text, 0, out var tag);
-            
+
             // Assert
             Assert.AreEqual(RichTextFixer.TagType.Opening, tag.Type);
             Assert.AreEqual(5, tag.Start);
             Assert.AreEqual(17, tag.End);
         }
-        
+
         [Test]
         public void FindTag_ProducesTheSameHash_ForOpeningTagsWithDifferentValues()
         {
             // Arrange
             var text1 = new FastStringBuilder("text <opening=12m> text");
             var text2 = new FastStringBuilder("text <opening=18s> text");
-            
+
             // Act
             RichTextFixer.FindTag(text1, 0, out var tag1);
             RichTextFixer.FindTag(text2, 0, out var tag2);
-            
+
             // Assert
             Assert.AreEqual(tag1.HashCode, tag2.HashCode);
         }
@@ -70,25 +70,25 @@ namespace RTLTMPro.Tests
         {
             // Arrange
             var text = new FastStringBuilder("text <opening/> text");
-            
+
             // Act
             RichTextFixer.FindTag(text, 0, out var tag);
-            
+
             // Assert
             Assert.AreEqual(RichTextFixer.TagType.SelfContained, tag.Type);
             Assert.AreEqual(5, tag.Start);
             Assert.AreEqual(14, tag.End);
         }
-        
+
         [Test]
         public void FindTag_FindsSelfContainedTagWithValue()
         {
             // Arrange
             var text = new FastStringBuilder("text <opening=15m/> text");
-            
+
             // Act
             RichTextFixer.FindTag(text, 0, out var tag);
-            
+
             // Assert
             Assert.AreEqual(RichTextFixer.TagType.SelfContained, tag.Type);
             Assert.AreEqual(5, tag.Start);
@@ -109,16 +109,16 @@ namespace RTLTMPro.Tests
             // Assert
             Assert.AreEqual(tag1.HashCode, tag2.HashCode);
         }
-        
+
         [Test]
         public void FindTag_FindsClosingTag()
         {
             // Arrange
             var text = new FastStringBuilder("text </closing> text");
-            
+
             // Act
             RichTextFixer.FindTag(text, 0, out var tag);
-            
+
             // Assert
             Assert.AreEqual(RichTextFixer.TagType.Closing, tag.Type);
             Assert.AreEqual(5, tag.Start);
@@ -137,7 +137,7 @@ namespace RTLTMPro.Tests
             RichTextFixer.FindTag(text2, 0, out var tag2);
 
             // Assert
-            Assert.AreEqual(tag1.HashCode, tag2.HashCode);   
+            Assert.AreEqual(tag1.HashCode, tag2.HashCode);
         }
 
         [Test]
@@ -145,10 +145,10 @@ namespace RTLTMPro.Tests
         {
             // Arrange
             var text = new FastStringBuilder("text");
-            
+
             // Act
             RichTextFixer.FindTag(text, 0, out var tag);
-            
+
             // Assert
             Assert.AreEqual(0, tag.Start);
             Assert.AreEqual(0, tag.End);
@@ -161,10 +161,10 @@ namespace RTLTMPro.Tests
         {
             // Arrange
             var text = new FastStringBuilder(" <tag> text");
-            
+
             // Act
             RichTextFixer.FindTag(text, 6, out var tag);
-            
+
             // Assert
             Assert.AreEqual(0, tag.Start);
             Assert.AreEqual(0, tag.End);
@@ -238,10 +238,10 @@ namespace RTLTMPro.Tests
         {
             // Arrange
             var text = new FastStringBuilder("text <self-contained/> text");
-            
+
             // Act
             RichTextFixer.Fix(text);
-            
+
             // Assert
             Assert.AreEqual("text >/deniatnoc-fles< text", text.ToString());
         }
@@ -251,36 +251,87 @@ namespace RTLTMPro.Tests
         {
             // Arrange
             var text = new FastStringBuilder("text <open> text");
-            
+
             // Act
             RichTextFixer.Fix(text);
-            
+
             // Assert
             Assert.AreEqual("text >nepo< text", text.ToString());
         }
-        
+
         [Test]
         public void Fix_Reverses_SimpleOpenAndClosingTag()
         {
             // Arrange
             var text = new FastStringBuilder("text </open> text <open>");
-            
+
             // Act
             RichTextFixer.Fix(text);
-            
+
             // Assert
             Assert.AreEqual("text >nepo/< text >nepo<", text.ToString());
         }
-        
+
         [Test]
         public void Fix_Reverses_SimpleOpenAndClosingTagWithValue()
         {
             // Arrange
             var text = new FastStringBuilder("text </open> text <open=134>");
-            
+
             // Act
             RichTextFixer.Fix(text);
-            
+
+            // Assert
+            Assert.AreEqual("text >nepo/< text >431=nepo<", text.ToString());
+        }
+        [Test]
+        public void Fix_Reverses_SelfContainedTags()
+        {
+            // Arrange
+            var text = new FastStringBuilder("text <self-contained/> text");
+
+            // Act
+            RichTextFixer.Fix(text, text);
+
+            // Assert
+            Assert.AreEqual("text >/deniatnoc-fles< text", text.ToString());
+        }
+
+        [Test]
+        public void Fix_Reverses_OpenTag_ThatDoesntHaveClosingTag()
+        {
+            // Arrange
+            var text = new FastStringBuilder("text <open> text");
+
+            // Act
+            RichTextFixer.Fix(text, text);
+
+            // Assert
+            Assert.AreEqual("text >nepo< text", text.ToString());
+        }
+
+        [Test]
+        public void Fix_Reverses_SimpleOpenAndClosingTag()
+        {
+            // Arrange
+            var text = new FastStringBuilder("text </open> text <open>");
+
+            // Act
+            RichTextFixer.Fix(text, text);
+
+            // Assert
+            Assert.AreEqual("text >nepo/< text >nepo<", text.ToString());
+        }
+
+        [Test]
+        public void Fix_Reverses_SimpleOpenAndClosingTagWithValue()
+        {
+            // Arrange
+            var text = new FastStringBuilder("text </open> text <open=134>");
+
+            // Act
+            RichTextFixer.Fix(text, text);
+
             // Assert
             Assert.AreEqual("text >nepo/< text >431=nepo<", text.ToString());
         }

--- a/Assets/RTLTMPro/Tests/RichTextFixerTests.cs
+++ b/Assets/RTLTMPro/Tests/RichTextFixerTests.cs
@@ -284,56 +284,5 @@ namespace RTLTMPro.Tests
             // Assert
             Assert.AreEqual("text >nepo/< text >431=nepo<", text.ToString());
         }
-        [Test]
-        public void Fix_Reverses_SelfContainedTags()
-        {
-            // Arrange
-            var text = new FastStringBuilder("text <self-contained/> text");
-
-            // Act
-            RichTextFixer.Fix(text, text);
-
-            // Assert
-            Assert.AreEqual("text >/deniatnoc-fles< text", text.ToString());
-        }
-
-        [Test]
-        public void Fix_Reverses_OpenTag_ThatDoesntHaveClosingTag()
-        {
-            // Arrange
-            var text = new FastStringBuilder("text <open> text");
-
-            // Act
-            RichTextFixer.Fix(text, text);
-
-            // Assert
-            Assert.AreEqual("text >nepo< text", text.ToString());
-        }
-
-        [Test]
-        public void Fix_Reverses_SimpleOpenAndClosingTag()
-        {
-            // Arrange
-            var text = new FastStringBuilder("text </open> text <open>");
-
-            // Act
-            RichTextFixer.Fix(text, text);
-
-            // Assert
-            Assert.AreEqual("text >nepo/< text >nepo<", text.ToString());
-        }
-
-        [Test]
-        public void Fix_Reverses_SimpleOpenAndClosingTagWithValue()
-        {
-            // Arrange
-            var text = new FastStringBuilder("text </open> text <open=134>");
-
-            // Act
-            RichTextFixer.Fix(text, text);
-
-            // Assert
-            Assert.AreEqual("text >nepo/< text >431=nepo<", text.ToString());
-        }
     }
 }


### PR DESCRIPTION
Hello, I made some changes to the plugin for my own use.
If you like you can add it to the the main project.
example:
![image](https://github.com/pnarimani/RTLTMPro/assets/68176509/5fd0e1c3-b5ee-4065-bcb8-1ee1b7cd7291)

problem:
this fix doesn't work if there is a space in the text.
![image](https://github.com/pnarimani/RTLTMPro/assets/68176509/35887c4b-a3bc-432e-bea4-3e91669c4354)
