### PR TITLE
Fix Unity 6 namespace error

### DIFF
--- a/Assets/RTLTMPro/Scripts/Editor/RTLTextMeshProEditor.cs
+++ b/Assets/RTLTMPro/Scripts/Editor/RTLTextMeshProEditor.cs
@@ -2,7 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 
-#if TMP_VERSION_2_1_0_OR_NEWER
+#if TMP_VERSION_2_1_0_OR_NEWER || UNITY_6000_0_OR_NEWER
 using TMP_UiEditorPanel = TMPro.EditorUtilities.TMP_EditorPanelUI;
 #else
 using TMP_UiEditorPanel = TMPro.EditorUtilities.TMP_UiEditorPanel;


### PR DESCRIPTION
Error:
Assets\RTLTMPro\Scripts\Editor\RTLTextMeshProEditor.cs(8,49): error CS0234: The type or namespace name 'TMP_UiEditorPanel' does not exist in the namespace 'TMPro.EditorUtilities' (are you missing an assembly reference?)